### PR TITLE
fix: directory pattern matching without trailing slash

### DIFF
--- a/src/codeowners.ts
+++ b/src/codeowners.ts
@@ -44,13 +44,12 @@ const compile = (rule: Rule): RuleMatcher => {
   }
 
   const matchers: Minimatch[] = []
-  const baseMatcher = new Minimatch(pattern, options)
   if (pattern.endsWith('/')) {
     matchers.push(new Minimatch(`${pattern}**`, options))
-  } else if (baseMatcher.hasMagic()) {
-    matchers.push(baseMatcher)
+  } else if (pattern.endsWith('*')) {
+    matchers.push(new Minimatch(pattern, options))
   } else {
-    matchers.push(baseMatcher)
+    matchers.push(new Minimatch(pattern, options))
     matchers.push(new Minimatch(`${pattern}/**`, options))
   }
 

--- a/src/codeowners.ts
+++ b/src/codeowners.ts
@@ -29,38 +29,43 @@ type RuleMatcher = {
 }
 
 const compile = (rule: Rule): RuleMatcher => {
-  let pattern = rule.pattern
+  const matchers = transformPatternForMinimatch(rule.pattern).map(
+    (pattern) =>
+      new Minimatch(pattern, {
+        dot: true,
+        nobrace: true,
+        nocomment: true,
+        noext: true,
+        nonegate: true,
+      }),
+  )
+  return {
+    match: (filename: string) => {
+      // Ensure the leading slash for matching.
+      if (!filename.startsWith('/')) {
+        filename = `/${filename}`
+      }
+      return matchers.some((matcher) => matcher.match(filename))
+    },
+    owners: rule.owners,
+  }
+}
+
+const transformPatternForMinimatch = (pattern: string): string[] => {
+  // Ensure the leading slash.
   if (pattern.startsWith('**')) {
     pattern = `/${pattern}`
   } else if (!pattern.startsWith('/')) {
     pattern = `/**/${pattern}`
   }
-  const options = {
-    dot: true,
-    nobrace: true,
-    nocomment: true,
-    noext: true,
-    nonegate: true,
-  }
 
-  const matchers: Minimatch[] = []
   if (pattern.endsWith('/')) {
-    matchers.push(new Minimatch(`${pattern}**`, options))
+    return [`${pattern}**`]
   } else if (pattern.endsWith('*')) {
-    matchers.push(new Minimatch(pattern, options))
+    return [pattern]
   } else {
-    matchers.push(new Minimatch(pattern, options))
-    matchers.push(new Minimatch(`${pattern}/**`, options))
-  }
-
-  return {
-    match: (filename: string) => {
-      if (!filename.startsWith('/')) {
-        filename = `/${filename}`
-      }
-      return matchers.some((m) => m.match(filename))
-    },
-    owners: rule.owners,
+    // A pattern without a trailing slash should match both the file and the directory.
+    return [pattern, `${pattern}/**`]
   }
 }
 

--- a/src/codeowners.ts
+++ b/src/codeowners.ts
@@ -44,12 +44,13 @@ const compile = (rule: Rule): RuleMatcher => {
   }
 
   const matchers: Minimatch[] = []
+  const baseMatcher = new Minimatch(pattern, options)
   if (pattern.endsWith('/')) {
     matchers.push(new Minimatch(`${pattern}**`, options))
-  } else if (pattern.endsWith('*')) {
-    matchers.push(new Minimatch(pattern, options))
+  } else if (baseMatcher.hasMagic()) {
+    matchers.push(baseMatcher)
   } else {
-    matchers.push(new Minimatch(pattern, options))
+    matchers.push(baseMatcher)
     matchers.push(new Minimatch(`${pattern}/**`, options))
   }
 

--- a/src/codeowners.ts
+++ b/src/codeowners.ts
@@ -35,22 +35,30 @@ const compile = (rule: Rule): RuleMatcher => {
   } else if (!pattern.startsWith('/')) {
     pattern = `/**/${pattern}`
   }
-  if (pattern.endsWith('/')) {
-    pattern = `${pattern}**`
-  }
-  const m = new Minimatch(pattern, {
+  const options = {
     dot: true,
     nobrace: true,
     nocomment: true,
     noext: true,
     nonegate: true,
-  })
+  }
+
+  const matchers: Minimatch[] = []
+  if (pattern.endsWith('/')) {
+    matchers.push(new Minimatch(`${pattern}**`, options))
+  } else if (pattern.endsWith('*')) {
+    matchers.push(new Minimatch(pattern, options))
+  } else {
+    matchers.push(new Minimatch(pattern, options))
+    matchers.push(new Minimatch(`${pattern}/**`, options))
+  }
+
   return {
     match: (filename: string) => {
       if (!filename.startsWith('/')) {
         filename = `/${filename}`
       }
-      return m.match(filename)
+      return matchers.some((m) => m.match(filename))
     },
     owners: rule.owners,
   }

--- a/tests/codeowners.test.ts
+++ b/tests/codeowners.test.ts
@@ -11,6 +11,7 @@ describe('class Matcher', () => {
     { pattern: 'logs/', owners: ['@logs-owner'] },
     { pattern: '/build/logs/', owners: ['@build-owner'] },
     { pattern: '/apps', owners: ['@apps-owner'] },
+    { pattern: '/apps/*-tests', owners: ['@apps-tests-owner'] },
     { pattern: 'config', owners: ['@config-owner'] },
   ])
 
@@ -28,6 +29,7 @@ describe('class Matcher', () => {
     { filename: 'apps/index.json', owners: ['@apps-owner'] },
     { filename: 'apps/deep/index.json', owners: ['@apps-owner'] },
     { filename: 'component/apps/index.json', owners: [] },
+    { filename: 'apps/foo-tests/foo.ts', owners: ['@apps-tests-owner'] },
     { filename: 'config', owners: ['@config-owner'] },
     { filename: 'config/test.json', owners: ['@config-owner'] },
     { filename: 'component/config/test.json', owners: ['@config-owner'] },

--- a/tests/codeowners.test.ts
+++ b/tests/codeowners.test.ts
@@ -10,6 +10,8 @@ describe('class Matcher', () => {
     { pattern: 'docs/*', owners: ['@docs-owner'] },
     { pattern: 'logs/', owners: ['@logs-owner'] },
     { pattern: '/build/logs/', owners: ['@build-owner'] },
+    { pattern: '/apps', owners: ['@apps-owner'] },
+    { pattern: 'config', owners: ['@config-owner'] },
   ])
 
   it.each([
@@ -22,6 +24,13 @@ describe('class Matcher', () => {
     { filename: 'logs/1.log', owners: ['@logs-owner'] },
     { filename: 'component/logs/1.log', owners: ['@logs-owner'] },
     { filename: 'build/logs/1.log', owners: ['@build-owner'] },
+    { filename: 'apps', owners: ['@apps-owner'] },
+    { filename: 'apps/index.json', owners: ['@apps-owner'] },
+    { filename: 'apps/deep/index.json', owners: ['@apps-owner'] },
+    { filename: 'component/apps/index.json', owners: [] },
+    { filename: 'config', owners: ['@config-owner'] },
+    { filename: 'config/test.json', owners: ['@config-owner'] },
+    { filename: 'component/config/test.json', owners: ['@config-owner'] },
   ])('returns $owners corresponding to $filename', ({ filename, owners }) => {
     const found = matcher.findOwners(filename)
     expect(found).toStrictEqual(owners)


### PR DESCRIPTION
## Summary
- Per the [gitignore spec](https://git-scm.com/docs/gitignore), CODEOWNERS patterns without a trailing slash (e.g. `/apps`, `config`) should match both the literal path and all files under that directory
  - > If there is a separator at the end of the pattern then the pattern will only match directories, otherwise the pattern can match both files and directories.
- Add a second `Minimatch` with `/**` suffix for non-glob patterns to correctly handle this case
- Patterns with trailing slash (`/docs/`) or glob (`docs/*`) are unaffected

## Test plan
- [x] Added test cases for anchored pattern without trailing slash (`/apps`) — literal, direct child, deep nesting, and negative (nested location)
- [x] Added test cases for unanchored pattern without trailing slash (`config`) — literal, direct child, and nested location
- [x] All existing tests pass unchanged
- [x] `pnpm check` (Biome lint/format) passes
- [x] `pnpm build` (ncc) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)